### PR TITLE
Patched to support the override of the base CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 CC= gcc
 
-CFLAGS=  -O3 -pipe # -g
+CFLAGS?=  -O3 -pipe # -g
 CFLAGS+= -D_REENTRANT -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 CFLAGS+= -Wno-parentheses
 ifeq ($(UNAME), Linux)


### PR DESCRIPTION
Modifica da CFLAGS= a CFLAGS?=, in questo modo il primo CFLAGS è sovrascrivibile a runtime.
Questo si rende necessario per passare i parametri di compilazione di default (-Ox -g parametri di hardening) nei sistemi di packaging, senza dover modificare Makefile.